### PR TITLE
fix: fix typos, cleanup labels, broken link, and template improvement

### DIFF
--- a/.github/ISSUE_TEMPLATE/C4GT_DMP_2025.yml
+++ b/.github/ISSUE_TEMPLATE/C4GT_DMP_2025.yml
@@ -45,6 +45,8 @@ body:
     attributes:
       label: Acceptance Criteria
       description: List the acceptance criteria for this feature.
+    validations:
+      required: true
 
   - type: textarea
     id: ticket-implementation-details
@@ -208,7 +210,7 @@ body:
         - Data Science
         - Deprecation
         - Documentation
-        - Delpoyment
+        - Deployment
         - Frontend
         - Internationalization
         - Localization

--- a/.github/ISSUE_TEMPLATE/c4gt_community.yml
+++ b/.github/ISSUE_TEMPLATE/c4gt_community.yml
@@ -1,7 +1,7 @@
 name: C4GT Community Template
 description: Create a new Ticket for C4GT Community
 title: "[C4GT Community]: "
-labels: ["Please add the C4GT Community Label on all tickets that you will list. In addition to this, please add whichever labels best describe your project from this list: C4GT Community, C4GT Coding, C4GT Design, C4GT Mentorship, C4GT Bounty, C4GT Advisory"]
+labels: ["C4GT Community"]
 body:
   - type: textarea
     id: ticket-description
@@ -42,6 +42,8 @@ body:
     attributes:
       label: Acceptance Criteria
       description: List the acceptance criteria for this feature.
+    validations:
+      required: true
 
   - type: textarea
     id: ticket-implementation-details
@@ -223,7 +225,7 @@ body:
         - Data Science
         - Deprecation
         - Documentation
-        - Delpoyment
+        - Deployment
         - Frontend
         - Internationalization
         - Localization

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To run API repositories locally, please follow the guide [here](https://piramal-
 | BeneficiaryID-Generation-API | [BeneficiaryID-Generation-API](https://github.com/PSMRI/BeneficiaryID-Generation-API) | AMRIT API microservice for generation and management of unique beneficiary IDs. | 8092 |
 | FHIR-API | [FHIR-API](https://github.com/PSMRI/FHIR-API) | Service that implements FHIR standard for healthcare information exchange between various systems that are used by clinicians and organisations | 8093 |
 | Identity-API | [Identity-API](https://github.com/PSMRI/Identity-API) | Identity API is a microservice that is used for the creation and management of beneficiaries. | 8094 |
-| Identity-1097-API | [Identity-API](https://github.com/PSMRI/Identity-API) | Identity-1097 API is a microservice that is used for the creation and management of beneficiaries(1097Identity Profile). | 8095 |
+| Identity-1097-API | [Identity-1097-API](https://github.com/PSMRI/Identity-API) | Identity-1097 API is a microservice that is used for the creation and management of beneficiaries (1097 Identity Profile). Runs as a separate instance of Identity-API. | 8095 |
 
 Note: These ports should be used when running the services in a local development environment.
 
@@ -89,14 +89,14 @@ Mobile applications are built with Kotlin and powered by AMRIT Platform REST API
 | FLW-Mobile-App | [FLW-Mobile-App](https://github.com/PSMRI/FLW-Mobile-App) | Android Application built in Kotlin. Powered by AMRIT Platform. FLW Mobile App is designed for healthcare programs and consultation services rendered by ASHAs to serve pregnant women, mothers, and newborns in India. |
 | HWC-Mobile-App | [HWC-Mobile-App](https://github.com/PSMRI/HWC-Mobile-App) | Android Application built with Kotlin for Health and Wellness Centre management. Takes care of workflows of CHOs, Doctors, Nurses, Lab technicians and Pharmacists. |
 
-#### Documentation repositories
+#### Infrastructure & Tooling repositories
 
-The following repositories contain documentation related to AMRIT Platform.
+The following repositories contain infrastructure, tooling, and documentation related to AMRIT Platform.
 
 | Repository Name | Link | Description |
 |------------------|------|-------------|
 | AMRIT-Docs | [AMRIT-Docs](https://github.com/PSMRI/AMRIT-Docs) | AMRIT developer documentation synced with GitBook. |
-| AMRIT-DB | [AMRIT-DB](https://github.com/PSMRI/AMRIT-DB) | DB service to simplify database schema management and setting up local environments. Using Flyway for migrations, it ensures consistency in DB schema for deployments. |
+| AMRIT-DB | [AMRIT-DB](https://github.com/PSMRI/AMRIT-DB) | Infrastructure tooling for database schema management. Uses Flyway migrations to ensure schema consistency across local and deployed environments. |
 | AMRIT-Website | [AMRIT-Website](https://github.com/PSMRI/AMRIT-Website) | Website for AMRIT. This is a forked repo to create AMRIT Website. |
 | AMRIT-DevOps | [AMRIT-DevOps](https://github.com/PSMRI/AMRIT-DevOps) | All things DevOps related for AMRIT are housed in this repo. |
 


### PR DESCRIPTION
## 📋 Description

JIRA ID: N/A

Fixed a typo (`Delpoyment` → `Deployment`) in both issue templates, cleaned up the `labels` field in `c4gt_community.yml` (was instruction text, not actual labels), made Acceptance Criteria required in both templates, fixed the `Identity-1097-API` link label in README (URL was correct, only the display text was wrong), and renamed the "Documentation repositories" section to "Infrastructure & Tooling" with an updated AMRIT-DB description to better reflect its actual purpose.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [x] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Changes verified by reviewing the raw file content before and after diffing. The `Identity-1097-API` repo (`PSMRI/Identity-1097-API`) was confirmed non-existent via search — the correct URL remains `PSMRI/Identity-API`, only the display label was corrected. No functional code was changed; all edits are limited to templates and README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Issue templates now require the acceptance criteria field
  * Fixed spelling error in category dropdown option
  * Updated repository documentation to clarify infrastructure and tooling sections with improved component descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->